### PR TITLE
fix(dependabot): allow major version bumps with manual review (closes #2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,19 @@ updates:
       time: "09:00"
       timezone: "Asia/Singapore"
     open-pull-requests-limit: 5
-    labels: ["dependencies"]
+    labels: ["dependencies", "ci"]
     commit-message:
       prefix: "chore"
       include: "scope"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+    # Group non-major updates into a single PR to reduce noise.
+    # Major version bumps still get individual PRs so we can read the
+    # changelog and decide per-action.
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+    # No blanket ignore on major bumps — dependabot surfaces them as PRs
+    # for manual review. Nothing is auto-merged: every major bump PR is
+    # reviewed against the action's changelog before merging. This is
+    # safer than ignoring majors entirely because security-relevant
+    # actions (actions/checkout, softprops/action-gh-release) otherwise
+    # have no visibility into upstream releases.


### PR DESCRIPTION
## Summary

- Removes the blanket \`version-update:semver-major\` ignore — major bumps now surface as PRs for manual review
- Adds \`actions-minor-patch\` group so minor/patch updates bundle into one weekly PR (reduces noise)
- Adds \`ci\` label to dependabot PRs alongside \`dependencies\`

Closes #2 SEC-003.

## Reasoning

The original ignore was a "stability" hedge, but dependabot PRs don't auto-merge. Ignoring majors means we never see PRs for them, never know they exist, and never get a prompt to read the changelog. Security-critical actions like \`actions/checkout\` have shipped important fixes in major bumps that this config was silently dropping.

Receiving a PR is the safer choice: it surfaces the update, we read the changelog, we decide.

## Test plan

- [x] YAML valid (\`python3 -c 'yaml.safe_load(...)'\`)
- [ ] Next weekly dependabot run (Monday) opens an actions-minor-patch group PR if any updates exist
- [ ] Any future major bump opens its own individual PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)