### PR TITLE
perf(install): remove redundant SHA256 verification after cmp -s (#4)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -201,20 +201,15 @@ install_skill() {
     die "Failed to copy SKILL.md to ${target} — check disk space and permissions"
   fi
 
-  # Verify copy — byte comparison + SHA256 checksum
+  # Verify copy with byte-level comparison against the source we just
+  # copied from. cmp -s short-circuits on the first differing byte and
+  # is the correct tool here: a SHA256 hash would only add value if we
+  # were verifying against an external reference (see CHECKSUMS.sha256),
+  # not against the source file itself.
   if ! cmp -s "${source}/SKILL.md" "${target}/SKILL.md"; then
     err "Verification failed — source and installed SKILL.md differ"
     err "Source: ${source}/SKILL.md"
     err "Target: ${target}/SKILL.md"
-    die "Installation may be corrupt. Try again with --force"
-  fi
-  local src_sha dst_sha
-  src_sha=$(shasum -a 256 "${source}/SKILL.md" | cut -d' ' -f1)
-  dst_sha=$(shasum -a 256 "${target}/SKILL.md" | cut -d' ' -f1)
-  if [ "$src_sha" != "$dst_sha" ]; then
-    err "SHA256 mismatch after copy"
-    err "Source: ${src_sha}"
-    err "Target: ${dst_sha}"
     die "Installation may be corrupt. Try again with --force"
   fi
 


### PR DESCRIPTION
## Summary

Removes the redundant SHA256 check in \`install_skill()\` that ran after \`cmp -s\` had already confirmed byte-identical content. Addresses PERF-003 from the bundled issue #4.

## Status of all sub-items in #4

| ID | Finding | Status in this PR |
|---|---|---|
| PERF-002 | Smoke test / BATS overlap | **Not actionable** — after PR #12 merged, BATS runs on Ubuntu only, so macOS installer-smoke-test is now the ONLY macOS coverage. Keeping it. |
| PERF-003 | Double integrity verification | **Fixed in this PR** |
| PERF-004 | Repeated grep/sed in validate-skills.sh | **Not actionable** — original recommendation was "No action needed at current scale." Still true. |
| PERF-006 | No CI caching for brew | **Superseded by #12** — BATS now runs on Ubuntu with apt-get (no brew). |
| PERF-007 | CI job consolidation | **Not actionable** — would save ~60s of billed runner time per run but regresses UX (single job means single status box, can't see which check failed at a glance). Current parallel design is fine. |

I'll close #4 with a comment summarizing this once this PR merges. 4 of 5 items end up being no-ops or superseded — only PERF-003 warranted a code change.

## Why cmp -s is sufficient

The goal of the check is "confirm the cp succeeded and the bytes match the source file." \`cmp -s\` does exactly this, byte-for-byte, and short-circuits on the first difference. SHA256 would only add value if we were verifying against an external reference hash (which is what \`CHECKSUMS.sha256\` is for — a separate concern). Running both was pure overhead.

## Test plan

- [x] \`shellcheck --severity=warning install.sh\`: clean
- [x] \`bats tests/install.bats\`: 15/15 passing (includes the "overwrites tampered install" test that exercises the verification path)
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)